### PR TITLE
Fix forms lose data

### DIFF
--- a/start.php
+++ b/start.php
@@ -105,6 +105,9 @@ function captcha_verify_action_hook($hook, $entity_type, $returnvalue, $params) 
 		return TRUE;
 	}
 
+	//Generate the sticky form, if we miss the captcha, will not loose the register form data
+	elgg_make_sticky_form($entity_type);
+
 	register_error(elgg_echo('captcha:captchafail'));
 
 	// forward to referrer or else action code sends to front page


### PR DESCRIPTION
Add sticky form generation, it fix a bug, when you fail the captcha now keeps the form data into session.
